### PR TITLE
Fix tx affinity logic when number of CPUs is above 32

### DIFF
--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -150,7 +150,8 @@ for q in $XPS; do
   xps_dwords=()
   for i in $(seq 0 $(((num_cpus - 1) / 32)))
   do
-    xps_dwords+=(`printf "%08x" $((xps & 0xffffffff))`)
+    xps_dwords=(`printf "%08x" $((xps & 0xffffffff))` "${xps_dwords[@]}")
+    xps=$((xps >> 32))
   done
   xps_string=$(IFS=, ; echo "${xps_dwords[*]}")
 

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -125,6 +125,7 @@ done
 
 XPS=/sys/class/net/e*/queues/tx*/xps_cpus
 num_cpus=$(nproc)
+[[ $num_cpus -gt 63 ]] && num_cpus=63
 
 num_queues=0
 for q in $XPS; do


### PR DESCRIPTION
When the number of CPUs is above 32, affinity string must be in the form: "high-order-dword,low-order-dword", but in fact it was 'low-order-dword,low-order-dword', causing "Value too large for defined data type" errors.

Changes done to fix this:
* Add missing bit shift operator
* Take care of the endianess