### PR TITLE
Updates the udev rules for local SSD disks.

### DIFF
--- a/src/lib/udev/rules.d/65-gce-disk-naming.rules
+++ b/src/lib/udev/rules.d/65-gce-disk-naming.rules
@@ -20,16 +20,9 @@ SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
 # SCSI naming
 KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
 
-# NVME naming
-KERNEL=="nvme0n1*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-0"
-KERNEL=="nvme0n2*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-1"
-KERNEL=="nvme0n3*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-2"
-KERNEL=="nvme0n4*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-3"
-KERNEL=="nvme0n5*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-4"
-KERNEL=="nvme0n6*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-5"
-KERNEL=="nvme0n7*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-6"
-KERNEL=="nvme0n8*", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-7"
-KERNEL=="nvme*", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
+# NVME Local SSD naming
+KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'echo $((%n-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
+KERNEL=="nvme*", ATTRS{model}=="nvme_card", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
 
 # Symlinks
 KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"


### PR DESCRIPTION
The current rules only allow for symlinks of up to 8 local SSD disks,
and also rely on the NVMe controller for the local drives being labeled
as nvme0*.  This updates the rule to check for the appropriate
model name "nvme_card", which always corresponds to the local SSD
controller, rather than relying on the device name.

The additional PROGRAM element is required to 0-index the nsid so
that this change doesn't alter the expected symlinks (a value of 0 for
a namespace ID is invalid according to the spec).