### PR TITLE
Updated udev rules

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,6 +10,7 @@ Package: google-compute-engine
 Architecture: all
 Depends: google-compute-engine-oslogin,
          google-guest-agent,
+         nvme-cli,
          ${misc:Depends}
 Recommends: rsyslog | system-log-daemon
 Provides: irqbalance

--- a/packaging/google-compute-engine.el6.spec
+++ b/packaging/google-compute-engine.el6.spec
@@ -47,6 +47,7 @@ install -d %{buildroot}/lib/
 cp -a src/lib/udev %{buildroot}/lib
 mkdir -p %{buildroot}/etc/dhcp
 ln -sf /usr/bin/google_set_hostname %{buildroot}/etc/dhcp/dhclient-exit-hooks
+rm /sr/lib/udev/google_nvme_id
 
 %files
 %defattr(0644,root,root,0755)

--- a/packaging/google-compute-engine.el6.spec
+++ b/packaging/google-compute-engine.el6.spec
@@ -47,7 +47,7 @@ install -d %{buildroot}/lib/
 cp -a src/lib/udev %{buildroot}/lib
 mkdir -p %{buildroot}/etc/dhcp
 ln -sf /usr/bin/google_set_hostname %{buildroot}/etc/dhcp/dhclient-exit-hooks
-rm /sr/lib/udev/google_nvme_id
+rm %{buildroot}/lib/udev/google_nvme_id
 
 %files
 %defattr(0644,root,root,0755)

--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -30,12 +30,7 @@ Requires: dracut
 Requires: google-compute-engine-oslogin
 Requires: google-guest-agent
 Requires: rsyslog
-
-# Only require nvme-cli on centos >= 6 and rhel >= 7 as older versions 
-# don't include this package
-%if 0%{?rhel} >= 7
-  Requires: nvme-cli
-%endif
+Requires: nvme-cli
 
 BuildArch: noarch
 

--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -31,6 +31,12 @@ Requires: google-compute-engine-oslogin
 Requires: google-guest-agent
 Requires: rsyslog
 
+# Only require nvme-cli on centos >= 6 and rhel >= 7 as older versions 
+# don't include this package
+%if 0%{?rhel} >= 7
+  Requires: nvme-cli
+%endif
+
 BuildArch: noarch
 
 # Allow other files in the source that don't end up in the package.

--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -1,0 +1,305 @@
+#!/bin/bash
+# Copyright 2020 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Used to generate symlinks for PD-NVMe devices using the disk names reported by
+# the metadata server
+
+# Locations of the script's dependencies
+readonly nvme_cli_bin=/usr/sbin/nvme
+
+# Flags to identify the disk type
+readonly LOCAL_SSD="LocalSsd"
+readonly PD="PersistentDisk"
+
+readonly NAMESPACE_NUMBER_REGEX="/dev/nvme[[:digit:]]+n([[:digit:]]+).*"
+readonly PARTITION_NUMBER_REGEX="/dev/nvme[[:digit:]]+n[[:digit:]]+p([[:digit:]]+)"
+
+# Globals used to generate the symlinks for a PD-NVMe disk
+ID_NAMESPACE_INDEX=''
+ID_SERIAL=''
+ID_SERIAL_SHORT=''
+
+#######################################
+# Helper function to log an error message to stderr.
+# Globals:
+#   None
+# Arguments:
+#   String to print as the log message
+# Outputs:
+#   Writes error to STDERR
+#######################################
+function err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+}
+
+#######################################
+# Retrieves the device name for an NVMe namespace using nvme-cli.
+# Globals:
+#   Uses nvme_cli_bin
+# Arguments:
+#   The path to the nvme namespace (/dev/nvme0n?)
+# Outputs:
+#   The device name parsed from the JSON in the vendor ext of the ns-id command.
+# Returns:
+#   0 if the device name for the namespace could be retrieved, 1 otherwise
+#######################################
+function get_namespace_device_name() {
+  local nvme_json
+  nvme_json="$("${nvme_cli_bin}" id-ns -b "${1}" | xxd -p -seek 384 -l 256 | xxd -p -r)"
+  if [[ $? != 0 ]]; then
+    return 1
+  fi
+
+  if [[ -z "${nvme_json}" ]]; then
+    err "NVMe Vendor Extension disk information not present"
+    return 1
+  fi
+
+  local device_name
+  device_name="$(echo "${nvme_json}" | sed -e 's/.*"device_name":"\([a-zA-Z0-9_-]\+\)".*/\1/g')"
+
+  # Error if our device name is empty
+  if [[ -z "${device_name}" ]]; then
+    err "Empty name"
+    return 1
+  fi
+
+  echo "${device_name}"
+  return 0
+}
+
+#######################################
+# Retrieves the nsid for an NVMe namespace
+# Globals:
+#   None
+# Arguments:
+#   The path to the nvme namespace (/dev/nvme0n*)
+# Outputs:
+#   The namespace number/id
+# Returns:
+#   0 if the namespace id could be retrieved, 1 otherwise
+#######################################
+function get_namespace_number() {
+  local dev_path="${1}"
+  local namespace_number
+  if [[ "${dev_path}" =~ $NAMESPACE_NUMBER_REGEX ]]; then
+    namespace_number="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+
+  echo "${namespace_number}"
+  return 0
+}
+
+#######################################
+# Retrieves the partition number for a device path if it exists
+# Globals:
+#   None
+# Arguments:
+#   The path to the device partition (/dev/nvme0n*p*)
+# Outputs:
+#   The value after 'p' in the device path, or an empty string if the path has
+#   no partition.
+#######################################
+function get_partition_number() {
+  local dev_path="${1}"
+  local partition_number
+  if [[ "${dev_path}" =~ $PARTITION_NUMBER_REGEX ]]; then
+    partition_number="${BASH_REMATCH[1]}"
+    echo "${partition_number}"
+  else
+    echo ''
+  fi
+  return 0
+}
+
+#######################################
+# Generates a symlink for a PD-NVMe device using the metadata's disk name.
+# Primarily used for testing but can be used if the script is directly invoked.
+# Globals:
+#   Uses ID_SERIAL_SHORT (can be populated by identify_pd_disk)
+# Arguments:
+#   The device path for the disk
+#######################################
+function gen_symlink() {
+  local dev_path="${1}"
+  local partition_number="$(get_partition_number "${dev_path}")"
+
+  if [[ -n "${partition_number}" ]]; then
+    ln -s "${dev_path}" /dev/disk/by-id/google-persistent-disk-"${ID_SERIAL_SHORT}"-part"${partition_number}" > /dev/null 2>&1
+  else
+    ln -s "${dev_path}" /dev/disk/by-id/google-persistent-disk-"${ID_SERIAL_SHORT}" > /dev/null 2>&1
+  fi
+
+  return 0
+}
+
+#######################################
+# Validates that a given path corresponds to a valid NVMe device
+# Globals:
+#   Uses nvme_cli_bin
+# Arguments:
+#   The device path for the disk
+# Returns:
+#   The return value of the call to the nvme id-ctrl command
+#######################################
+function validate_nvme_device() {
+  "${nvme_cli_bin}" id-ctrl "${1}" &>/dev/null
+}
+
+#######################################
+# Determines if the device path is a PD or Local SSD disk
+# Globals:
+#   Uses nvme_cli_bin, PD, and LOCAL_SSD
+# Arguments:
+#   The device path for the disk
+# Returns:
+#   1 if the device type is Unknown, 0 on success
+#######################################
+function detect_pd_or_local_ssd() {
+  local nvme_id_ctrl
+  nvme_id_ctrl="$("${nvme_cli_bin}" id-ctrl "${1}")"
+  if [[ "${nvme_id_ctrl}" =~ 'nvme_card-pd' ]]; then
+    echo "${PD}"
+  elif [[ "${nvme_id_ctrl}" =~ 'nvme_card' ]]; then
+    echo "${LOCAL_SSD}"
+  else
+    return 1
+  fi
+  return 0
+}
+
+#######################################
+# Populates the ID_* global variables with a disk's device name and namespace
+# Globals:
+#   Populates ID_NAMESPACE_INDEX, ID_SERIAL_SHORT, and ID_SERIAL
+# Arguments:
+#   The device path for the disk
+# Returns:
+#   0 on success and 255 if an error occurrs
+#######################################
+function identify_pd_disk() {
+  local dev_path="${1}"
+  local dev_name
+  dev_name="$(get_namespace_device_name "${dev_path}")"
+  if [[ $? != 0 ]]; then
+    return 255
+  fi
+
+  ID_NAMESPACE_INDEX="${namespace_index}"
+  ID_SERIAL_SHORT="${dev_name}"
+  ID_SERIAL="Google_PersistentDisk_${ID_SERIAL_SHORT}"
+  return 0
+}
+
+#######################################
+# Ensures a given command/path exists
+# Arguments:
+#   The path for the command
+# Returns:
+#   0 if the command is found/executable and 1 on error
+#######################################
+function confirm_command() {
+  local command_to_check="${1}"
+  command -v "${command_to_check}" > /dev/null 2>&1
+  if [[ $? != 0 ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+function print_help_message() {
+  echo "Usage: google_nvme_id [-s] [-h] -d device_path"
+  echo "  -d <device_path> (Required): Specifies the path to generate a name"
+  echo "        for.  This needs to be a path to an nvme device or namespace"
+  echo "  -s: Create symbolic link for the disk under /dev/disk/by-id."
+  echo "        Otherwise, the disk name will be printed to STDOUT"
+  echo "  -h: Print this help message"
+}
+
+function main() {
+  local opt_gen_symlink='false'
+  local device_path=''
+
+  while getopts :d:sh flag; do
+    case "${flag}" in
+      d) device_path="${OPTARG}";;
+      s) opt_gen_symlink='true';;
+      h) print_help_message
+         return 0
+         ;;
+      :) echo "Invalid option: ${OPTARG} requires an argument" 1>&2
+         return 1
+         ;;
+      *) return 1
+    esac
+  done
+
+  if [[ -z "$device_path" ]]; then
+    echo "Device path (-d) argument required. Use -h for full usage." 1>&2
+    exit 1
+  fi
+
+  confirm_command "${nvme_cli_bin}"
+  if [[ $? != 0 ]]; then
+    local err_msg="The nvme utility (/usr/sbin/nvme) was not found."
+    err_msg="${err_msg} You may need to run with sudo or install nvme-cli."
+    err "${err_msg}"
+    return 1
+  fi
+
+  # Ensure the passed device is actually an NVMe device
+  validate_nvme_device "${device_path}"
+  if [[ $? != 0 ]]; then
+    local err_msg="Passed device was not an NVMe device.  (You may need to run"
+    err_msg="${err_msg} this script as root/with sudo)."
+    err "${err_msg}"
+    return 1
+  fi
+
+  # Detect the type of attached nvme device
+  local device_type="$(detect_pd_or_local_ssd "${device_path}")"
+  local device_type_ret_value=$?
+  if [[ "${device_type}" == "${LOCAL_SSD}" ]]; then
+    err "This script only supports PD NVMe disks but given path was Local SSD"
+    return 1
+  elif [[ "${device_type_ret_value}" != 0 ]]; then
+    err "Unknown device type (neither a PD nor Local SSD NVMe device)"
+    return 1
+  fi
+
+  # Fill the global variables for the id command for the given disk type
+  identify_pd_disk "${device_path}"
+  identify_ret_value=$?
+
+  # Error messages will be printed closer to error, no need to reprint here
+  if [[ "${identify_ret_value}" != 0 ]]; then
+    return "${identify_ret_value}"
+  fi
+
+  # Gen symlinks or print out the globals set by the identify command
+  if [[ "${opt_gen_symlink}" == 'true' ]]; then
+    gen_symlink "${device_path}"
+  else
+    echo "ID_SERIAL_SHORT=${ID_SERIAL_SHORT}"
+    echo "ID_SERIAL=${ID_SERIAL}"
+  fi
+
+  return $?
+
+}
+main "$@"

--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -66,7 +66,7 @@ function get_namespace_device_name() {
   fi
 
   local device_name
-  device_name="$(echo "$nvme_json" | sed -e 's/.*"device_name":"\([a-zA-Z0-9_-]\+\)".*/\1/g')"
+  device_name="$(echo "$nvme_json" | grep device_name | sed -e 's/.*"device_name":[  \t]*"\([a-zA-Z0-9_-]\+\)".*/\1/')"
 
   # Error if our device name is empty
   if [[ -z "$device_name" ]]; then

--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -137,9 +137,9 @@ function gen_symlink() {
   local partition_number="$(get_partition_number "$dev_path")"
 
   if [[ -n "$partition_number" ]]; then
-    ln -s "$dev_path" /dev/disk/by-id/google-persistent-disk-"$ID_SERIAL_SHORT"-part"$partition_number" > /dev/null 2>&1
+    ln -s "$dev_path" /dev/disk/by-id/google-"$ID_SERIAL_SHORT"-part"$partition_number" > /dev/null 2>&1
   else
-    ln -s "$dev_path" /dev/disk/by-id/google-persistent-disk-"$ID_SERIAL_SHORT" > /dev/null 2>&1
+    ln -s "$dev_path" /dev/disk/by-id/google-"$ID_SERIAL_SHORT" > /dev/null 2>&1
   fi
 
   return 0

--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -152,14 +152,14 @@ function gen_symlink() {
 # Arguments:
 #   The device path for the disk
 # Returns:
-#   0 on success and 255 if an error occurrs
+#   0 on success and 1 if an error occurrs
 #######################################
 function identify_pd_disk() {
   local dev_path="$1"
   local dev_name
   dev_name="$(get_namespace_device_name "$dev_path")"
   if [[ $? -ne 0 ]]; then
-    return 255
+    return 1
   fi
 
   ID_SERIAL_SHORT="$dev_name"

--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -19,15 +19,13 @@
 # Locations of the script's dependencies
 readonly nvme_cli_bin=/usr/sbin/nvme
 
-# Flags to identify the disk type
-readonly LOCAL_SSD="LocalSsd"
-readonly PD="PersistentDisk"
-
+# Bash regex to parse device paths and controller identification
 readonly NAMESPACE_NUMBER_REGEX="/dev/nvme[[:digit:]]+n([[:digit:]]+).*"
 readonly PARTITION_NUMBER_REGEX="/dev/nvme[[:digit:]]+n[[:digit:]]+p([[:digit:]]+)"
+readonly PD_NVME_REGEX="sn[[:space:]]+:[[:space]]+nvme_card-pd"
 
-# Globals used to generate the symlinks for a PD-NVMe disk
-ID_NAMESPACE_INDEX=''
+# Globals used to generate the symlinks for a PD-NVMe disk.  These are populated
+# by the identify_pd_disk function and exported for consumption by udev rules.
 ID_SERIAL=''
 ID_SERIAL_SHORT=''
 
@@ -57,26 +55,26 @@ function err() {
 #######################################
 function get_namespace_device_name() {
   local nvme_json
-  nvme_json="$("${nvme_cli_bin}" id-ns -b "${1}" | xxd -p -seek 384 -l 256 | xxd -p -r)"
-  if [[ $? != 0 ]]; then
+  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r)"
+  if [[ $? -ne 0 ]]; then
     return 1
   fi
 
-  if [[ -z "${nvme_json}" ]]; then
+  if [[ -z "$nvme_json" ]]; then
     err "NVMe Vendor Extension disk information not present"
     return 1
   fi
 
   local device_name
-  device_name="$(echo "${nvme_json}" | sed -e 's/.*"device_name":"\([a-zA-Z0-9_-]\+\)".*/\1/g')"
+  device_name="$(echo "$nvme_json" | sed -e 's/.*"device_name":"\([a-zA-Z0-9_-]\+\)".*/\1/g')"
 
   # Error if our device name is empty
-  if [[ -z "${device_name}" ]]; then
+  if [[ -z "$device_name" ]]; then
     err "Empty name"
     return 1
   fi
 
-  echo "${device_name}"
+  echo "$device_name"
   return 0
 }
 
@@ -92,15 +90,15 @@ function get_namespace_device_name() {
 #   0 if the namespace id could be retrieved, 1 otherwise
 #######################################
 function get_namespace_number() {
-  local dev_path="${1}"
+  local dev_path="$1"
   local namespace_number
-  if [[ "${dev_path}" =~ $NAMESPACE_NUMBER_REGEX ]]; then
+  if [[ "$dev_path" =~ $NAMESPACE_NUMBER_REGEX ]]; then
     namespace_number="${BASH_REMATCH[1]}"
   else
     return 1
   fi
 
-  echo "${namespace_number}"
+  echo "$namespace_number"
   return 0
 }
 
@@ -115,11 +113,11 @@ function get_namespace_number() {
 #   no partition.
 #######################################
 function get_partition_number() {
-  local dev_path="${1}"
+  local dev_path="$1"
   local partition_number
-  if [[ "${dev_path}" =~ $PARTITION_NUMBER_REGEX ]]; then
+  if [[ "$dev_path" =~ $PARTITION_NUMBER_REGEX ]]; then
     partition_number="${BASH_REMATCH[1]}"
-    echo "${partition_number}"
+    echo "$partition_number"
   else
     echo ''
   fi
@@ -135,91 +133,38 @@ function get_partition_number() {
 #   The device path for the disk
 #######################################
 function gen_symlink() {
-  local dev_path="${1}"
-  local partition_number="$(get_partition_number "${dev_path}")"
+  local dev_path="$1"
+  local partition_number="$(get_partition_number "$dev_path")"
 
-  if [[ -n "${partition_number}" ]]; then
-    ln -s "${dev_path}" /dev/disk/by-id/google-persistent-disk-"${ID_SERIAL_SHORT}"-part"${partition_number}" > /dev/null 2>&1
+  if [[ -n "$partition_number" ]]; then
+    ln -s "$dev_path" /dev/disk/by-id/google-persistent-disk-"$ID_SERIAL_SHORT"-part"$partition_number" > /dev/null 2>&1
   else
-    ln -s "${dev_path}" /dev/disk/by-id/google-persistent-disk-"${ID_SERIAL_SHORT}" > /dev/null 2>&1
+    ln -s "$dev_path" /dev/disk/by-id/google-persistent-disk-"$ID_SERIAL_SHORT" > /dev/null 2>&1
   fi
 
-  return 0
-}
-
-#######################################
-# Validates that a given path corresponds to a valid NVMe device
-# Globals:
-#   Uses nvme_cli_bin
-# Arguments:
-#   The device path for the disk
-# Returns:
-#   The return value of the call to the nvme id-ctrl command
-#######################################
-function validate_nvme_device() {
-  "${nvme_cli_bin}" id-ctrl "${1}" &>/dev/null
-}
-
-#######################################
-# Determines if the device path is a PD or Local SSD disk
-# Globals:
-#   Uses nvme_cli_bin, PD, and LOCAL_SSD
-# Arguments:
-#   The device path for the disk
-# Returns:
-#   1 if the device type is Unknown, 0 on success
-#######################################
-function detect_pd_or_local_ssd() {
-  local nvme_id_ctrl
-  nvme_id_ctrl="$("${nvme_cli_bin}" id-ctrl "${1}")"
-  if [[ "${nvme_id_ctrl}" =~ 'nvme_card-pd' ]]; then
-    echo "${PD}"
-  elif [[ "${nvme_id_ctrl}" =~ 'nvme_card' ]]; then
-    echo "${LOCAL_SSD}"
-  else
-    return 1
-  fi
   return 0
 }
 
 #######################################
 # Populates the ID_* global variables with a disk's device name and namespace
 # Globals:
-#   Populates ID_NAMESPACE_INDEX, ID_SERIAL_SHORT, and ID_SERIAL
+#   Populates ID_SERIAL_SHORT, and ID_SERIAL
 # Arguments:
 #   The device path for the disk
 # Returns:
 #   0 on success and 255 if an error occurrs
 #######################################
 function identify_pd_disk() {
-  local dev_path="${1}"
+  local dev_path="$1"
   local dev_name
-  dev_name="$(get_namespace_device_name "${dev_path}")"
-  if [[ $? != 0 ]]; then
+  dev_name="$(get_namespace_device_name "$dev_path")"
+  if [[ $? -ne 0 ]]; then
     return 255
   fi
 
-  ID_NAMESPACE_INDEX="${namespace_index}"
-  ID_SERIAL_SHORT="${dev_name}"
+  ID_SERIAL_SHORT="$dev_name"
   ID_SERIAL="Google_PersistentDisk_${ID_SERIAL_SHORT}"
   return 0
-}
-
-#######################################
-# Ensures a given command/path exists
-# Arguments:
-#   The path for the command
-# Returns:
-#   0 if the command is found/executable and 1 on error
-#######################################
-function confirm_command() {
-  local command_to_check="${1}"
-  command -v "${command_to_check}" > /dev/null 2>&1
-  if [[ $? != 0 ]]; then
-    return 1
-  else
-    return 0
-  fi
 }
 
 function print_help_message() {
@@ -236,8 +181,8 @@ function main() {
   local device_path=''
 
   while getopts :d:sh flag; do
-    case "${flag}" in
-      d) device_path="${OPTARG}";;
+    case "$flag" in
+      d) device_path="$OPTARG";;
       s) opt_gen_symlink='true';;
       h) print_help_message
          return 0
@@ -254,47 +199,42 @@ function main() {
     exit 1
   fi
 
-  confirm_command "${nvme_cli_bin}"
-  if [[ $? != 0 ]]; then
-    local err_msg="The nvme utility (/usr/sbin/nvme) was not found."
-    err_msg="${err_msg} You may need to run with sudo or install nvme-cli."
-    err "${err_msg}"
+  # Ensure the nvme-cli command is installed
+  command -v "$nvme_cli_bin" > /dev/null 2>&1
+  if [[ $? -ne 0 ]]; then
+    err "The nvme utility (/usr/sbin/nvme) was not found. You may need to run \
+with sudo or install nvme-cli."
     return 1
   fi
 
   # Ensure the passed device is actually an NVMe device
-  validate_nvme_device "${device_path}"
-  if [[ $? != 0 ]]; then
-    local err_msg="Passed device was not an NVMe device.  (You may need to run"
-    err_msg="${err_msg} this script as root/with sudo)."
-    err "${err_msg}"
+  "$nvme_cli_bin" id-ctrl "$device_path" &>/dev/null
+  if [[ $? -ne 0 ]]; then
+    err "Passed device was not an NVMe device.  (You may need to run this \
+script as root/with sudo)."
     return 1
   fi
 
   # Detect the type of attached nvme device
-  local device_type="$(detect_pd_or_local_ssd "${device_path}")"
-  local device_type_ret_value=$?
-  if [[ "${device_type}" == "${LOCAL_SSD}" ]]; then
-    err "This script only supports PD NVMe disks but given path was Local SSD"
-    return 1
-  elif [[ "${device_type_ret_value}" != 0 ]]; then
-    err "Unknown device type (neither a PD nor Local SSD NVMe device)"
+  local controller_id
+  controller_id=$("$nvme_cli_bin" id-ctrl "$device_path")
+  if [[ ! "$controller_id" =~ nvme_card-pd ]] ; then
+    err "Device is not a PD-NVMe device"
     return 1
   fi
 
   # Fill the global variables for the id command for the given disk type
-  identify_pd_disk "${device_path}"
-  identify_ret_value=$?
-
   # Error messages will be printed closer to error, no need to reprint here
-  if [[ "${identify_ret_value}" != 0 ]]; then
-    return "${identify_ret_value}"
+  identify_pd_disk "$device_path"
+  if [[ $? -ne 0 ]]; then
+    return $?
   fi
 
   # Gen symlinks or print out the globals set by the identify command
-  if [[ "${opt_gen_symlink}" == 'true' ]]; then
-    gen_symlink "${device_path}"
+  if [[ "$opt_gen_symlink" == 'true' ]]; then
+    gen_symlink "$device_path"
   else
+    # These will be consumed by udev
     echo "ID_SERIAL_SHORT=${ID_SERIAL_SHORT}"
     echo "ID_SERIAL=${ID_SERIAL}"
   fi

--- a/src/lib/udev/rules.d/64-gce-disk-removal.rules
+++ b/src/lib/udev/rules.d/64-gce-disk-removal.rules
@@ -14,4 +14,4 @@
 #
 # When a disk is removed, unmount any remaining attached volumes.
 
-ACTION=="remove", SUBSYSTEM=="block", KERNEL=="sd*|vd*", RUN+="/bin/sh -c '/bin/umount -fl /dev/$name && /usr/bin/logger -p daemon.warn -s WARNING: hot-removed /dev/$name that was still mounted, data may have been corrupted'"
+ACTION=="remove", SUBSYSTEM=="block", KERNEL=="sd*|vd*|nvme*", RUN+="/bin/sh -c '/bin/umount -fl /dev/$name && /usr/bin/logger -p daemon.warn -s WARNING: hot-removed /dev/$name that was still mounted, data may have been corrupted'"

--- a/src/lib/udev/rules.d/65-gce-disk-naming.rules
+++ b/src/lib/udev/rules.d/65-gce-disk-naming.rules
@@ -24,6 +24,9 @@ KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
 KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'echo $((%n-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
 KERNEL=="nvme*", ATTRS{model}=="nvme_card", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
 
+# NVME Persistent Disk Naming
+KERNEL=="nvme*n*", ATTRS{model}=="nvme_card-pd", IMPORT{program}="google_nvme_id -d $tempnode"
+
 # Symlinks
 KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
 KERNEL=="sd*|vd*|nvme*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}-part%n"


### PR DESCRIPTION
This PR adds additional udev rules and a script to support disk identification for PD NVMe disks.  

It requires the nvme-cli tool (updated in package configurations) and a specific vendor extension to the NVMe device/controller.  The disk name will be present in this field (along with some other metadata).

It was tested in the following configurations:
    - Devcluster with multiple NVMe disks attached (symlinks created including links for specific partitions)
    - Staging & Devcluster with missing nvme-cli tool (boot successful but no symlink, which is expected)
    - Staging with missing vendor extension (boot successful and no symlink, which is expected)


