### PR TITLE
correct udev rule syntax

### DIFF
--- a/src/lib/udev/rules.d/65-gce-disk-naming.rules
+++ b/src/lib/udev/rules.d/65-gce-disk-naming.rules
@@ -21,7 +21,7 @@ SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
 KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
 
 # NVME Local SSD naming
-KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'echo $((%n-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
+KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'echo $$((%n-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
 KERNEL=="nvme*", ATTRS{model}=="nvme_card", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
 
 # NVME Persistent Disk Naming


### PR DESCRIPTION
udev substitution rules support both % and $ syntax, so the `$(())` arithmetic syntax here is first attempted as a udev substitution and fails with a warning. it has no apparent impact beyond the warning, udev falls back to sending the not-substituted text.

Fixes: #14  