### PR TITLE
dracut.conf wants spaces around values

### DIFF
--- a/src/etc/dracut.conf.d/gce.conf
+++ b/src/etc/dracut.conf.d/gce.conf
@@ -1,2 +1,2 @@
 # Include NVMe driver in initrd to boot on NVMe devices.
-force_drivers+="nvme"
+force_drivers+=" nvme "


### PR DESCRIPTION
In Fedora 33, this config file causes the warning:

```
dracut: WARNING: <key>+=" <values> ": <values> should have surrounding white spaces!
dracut: WARNING: This will lead to unwanted side effects! Please fix the configuration file.
```

When executing `dracut --force` in `%post`