### PR TITLE
use grep for hostname check

### DIFF
--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -16,18 +16,17 @@
 # Deal with a new hostname assignment.
 
 if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
-  # Don't allow DHCP responses with the MDS as the hostname.
-  # See: https://github.com/irsl/gcp-dhcp-takeover-code-exec
-  if echo "$new_host_name" | grep -iq "metadata.google.internal"; then
-    echo 'not setting invalid hostname'
-    exit 0
-  fi
-
   # Delete entries with new_host_name or new_ip_address in /etc/hosts.
   sed -i"" '/Added by Google/d' /etc/hosts
 
-  # Add an entry for our new_host_name/new_ip_address in /etc/hosts.
-  echo "${new_ip_address} ${new_host_name} ${new_host_name%%.*}  # Added by Google" >> /etc/hosts
+  # Don't allow DHCP responses with the MDS as the hostname.
+  # See: https://github.com/irsl/gcp-dhcp-takeover-code-exec
+  if echo "$new_host_name" | grep -iq "metadata.google.internal"; then
+    echo "not setting invalid hostname"
+  else
+    # Add an entry for our new_host_name/new_ip_address in /etc/hosts.
+    echo "${new_ip_address} ${new_host_name} ${new_host_name%%.*}  # Added by Google" >> /etc/hosts
+  fi
 
   # Add an entry for reaching the metadata server in /etc/hosts.
   echo "169.254.169.254 metadata.google.internal  # Added by Google" >> /etc/hosts
@@ -43,7 +42,7 @@ fi
 # As a result, we set the host name in all circumstances here, to the truncated
 # unqualified domain name.
 
-if [ -n "$new_host_name" ]; then
+if [ -n "$new_host_name" ] && ! echo "$new_host_name" | grep -iq "metadata.google.internal"; then
   hostname "${new_host_name%%.*}"
 
   # If NetworkManager is installed set the hostname with nmcli.

--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -18,7 +18,7 @@
 if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
   # Don't allow DHCP responses with the MDS as the hostname.
   # See: https://github.com/irsl/gcp-dhcp-takeover-code-exec
-  if [[ "$new_host_name" =~ "metadata.google.internal" ]]; then
+  if echo "$new_host_name" | grep -iq "metadata.google.internal"; then
     echo 'not setting invalid hostname'
     exit 0
   fi


### PR DESCRIPTION
improve the metadata exploit detection
* use grep for case insensitive matching
* wrap actions in conditions rather than exiting

the script is sourced rather than executed on some systems, and this will cause 'exit 0' to promulgate to the sourcing function, causing a premature exit and leaving the system unconfigured.