### PR TITLE
dont set IP in etc/hosts; remove rsyslog

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -12,7 +12,6 @@ Depends: google-compute-engine-oslogin,
          google-guest-agent,
          nvme-cli,
          ${misc:Depends}
-Recommends: rsyslog | system-log-daemon
 Provides: irqbalance
 Conflicts: google-compute-engine-jessie,
            google-compute-engine-init-jessie,

--- a/packaging/debian/install
+++ b/packaging/debian/install
@@ -1,6 +1,5 @@
 etc/apt/apt.conf.d/*
 etc/modprobe.d/*
-etc/rsyslog.d/*
 etc/sysctl.d/*
 lib/udev/rules.d/*
 lib/udev/*

--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -29,7 +29,6 @@ Requires: curl
 Requires: dracut
 Requires: google-compute-engine-oslogin
 Requires: google-guest-agent
-Requires: rsyslog
 Requires: nvme-cli
 
 BuildArch: noarch
@@ -58,7 +57,6 @@ cp -a src/lib/udev/google_nvme_id %{buildroot}/%{_udevrulesdir}/../
 %{_udevrulesdir}/../google_nvme_id
 %config /etc/dracut.conf.d/*
 %config /etc/modprobe.d/*
-%config /etc/rsyslog.d/*
 %config /etc/sysctl.d/*
 
 %pre

--- a/src/etc/rsyslog.d/90-google.conf
+++ b/src/etc/rsyslog.d/90-google.conf
@@ -1,6 +1,0 @@
-# Google Compute Engine default console logging.
-#
-# daemon: logging from Google provided daemons.
-# kern: logging information in case of an unexpected crash during boot.
-#
-daemon,kern.* /dev/console

--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -16,7 +16,7 @@
 # Deal with a new hostname assignment.
 
 if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
-  # Delete entries with new_host_name or new_ip_address in /etc/hosts.
+  # Delete Google-added entries in /etc/hosts.
   sed -i"" '/Added by Google/d' /etc/hosts
 
   # Don't allow DHCP responses with the MDS as the hostname.
@@ -24,8 +24,8 @@ if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
   if echo "$new_host_name" | grep -iq "metadata.google.internal"; then
     echo "not setting invalid hostname"
   else
-    # Add an entry for our new_host_name/new_ip_address in /etc/hosts.
-    echo "${new_ip_address} ${new_host_name} ${new_host_name%%.*}  # Added by Google" >> /etc/hosts
+    # Add an entry for our new_host_name in /etc/hosts.
+    echo "127.0.0.2 ${new_host_name} ${new_host_name%%.*}  # Added by Google" >> /etc/hosts
   fi
 
   # Add an entry for reaching the metadata server in /etc/hosts.
@@ -48,19 +48,8 @@ if [ -n "$new_host_name" ] && ! echo "$new_host_name" | grep -iq "metadata.googl
   # If NetworkManager is installed set the hostname with nmcli.
   # to resolve issues with NetworkManager resetting the hostname
   # to the FQDN on DHCP renew.
-  nmcli=$(which nmcli 2> /dev/null)
-  if [ -x "$nmcli" ]; then
-    nmcli general hostname "${new_host_name%%.*}"
-  fi
+  nmcli general hostname "${new_host_name%%.*}" >/dev/null 2>&1 || :
 
   # Restart rsyslog to update the hostname.
-  systemctl=$(which systemctl 2> /dev/null)
-  if [ -x "$systemctl" ]; then
-    hasrsyslog=$($systemctl | grep rsyslog | cut -f1 -d' ')
-    if [ ! -z "$hasrsyslog" ]; then
-      $systemctl -q --no-block restart "$hasrsyslog"
-    fi
-  else
-    pkill -HUP syslogd
-  fi
+  systemctl -q --no-block restart rsyslog >/dev/null 2>&1 || :
 fi


### PR DESCRIPTION
* Set hostname entry to always use 127.0.0.2
* Remove all rsyslog-related code except for the exit hook restart
* Don't care if nmcli or rsyslog restart fail (this script must not fail)