### PR TITLE
restore rsyslog

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -12,6 +12,7 @@ Depends: google-compute-engine-oslogin,
          google-guest-agent,
          nvme-cli,
          ${misc:Depends}
+Recommends: rsyslog | system-log-daemon
 Provides: irqbalance
 Conflicts: google-compute-engine-jessie,
            google-compute-engine-init-jessie,

--- a/packaging/debian/install
+++ b/packaging/debian/install
@@ -1,5 +1,6 @@
 etc/apt/apt.conf.d/*
 etc/modprobe.d/*
+etc/rsyslog.d/*
 etc/sysctl.d/*
 lib/udev/rules.d/*
 lib/udev/*

--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -29,6 +29,7 @@ Requires: curl
 Requires: dracut
 Requires: google-compute-engine-oslogin
 Requires: google-guest-agent
+Requires: rsyslog
 Requires: nvme-cli
 
 BuildArch: noarch
@@ -57,6 +58,7 @@ cp -a src/lib/udev/google_nvme_id %{buildroot}/%{_udevrulesdir}/../
 %{_udevrulesdir}/../google_nvme_id
 %config /etc/dracut.conf.d/*
 %config /etc/modprobe.d/*
+%config /etc/rsyslog.d/*
 %config /etc/sysctl.d/*
 
 %pre

--- a/src/etc/rsyslog.d/90-google.conf
+++ b/src/etc/rsyslog.d/90-google.conf
@@ -1,0 +1,6 @@
+# Google Compute Engine default console logging.
+#
+# daemon: logging from Google provided daemons.
+# kern: logging information in case of an unexpected crash during boot.
+#
+daemon,kern.* /dev/console


### PR DESCRIPTION
Partial rollback of #26 where we tested building without rsyslog. Seems we want to keep it around for now.