### PR TITLE
Fix NVMe local SSD PROGRAM REGEX

### DIFF
--- a/src/lib/udev/rules.d/65-gce-disk-naming.rules
+++ b/src/lib/udev/rules.d/65-gce-disk-naming.rules
@@ -21,7 +21,7 @@ SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
 KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
 
 # NVME Local SSD naming
-KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'nsid=$$(echo %k|sed -re s/nvme.n\(.\).\*/\\1/); echo $$((nsid-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
+KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'nsid=$$(echo %k|sed -re s/nvme[0-9]+n\([0-9]+\).\*/\\1/); echo $$((nsid-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
 KERNEL=="nvme*", ATTRS{model}=="nvme_card", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"
 
 # NVME Persistent Disk Naming


### PR DESCRIPTION
GCE supports up to 24 NVMe local SSDs, but the regex in the PROGRAM field only looks for the last digit of the given string causing issues when there are >= 10 local SSDs. Changed REGEX to get the last number of the string instead to support the up to 24 local SSDs.