### PR TITLE
Update google_set_multiqueue

### DIFF
--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -134,6 +134,8 @@ done
 
 # If we have more CPUs than queues, then stripe CPUs across tx affinity
 # as CPUNumber % queue_count.
+# Be aware, striping CPUs across tx queue may not yield best throughput. In that case, only affilliate
+# the CPUs handling tx TRQ to the coresponding tx queue, leave rest of CPUs alone.
 for q in $XPS; do
   queue_re=".*tx-([0-9]+).*$"
   if [[ "$q" =~ ${queue_re} ]]; then

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -134,8 +134,8 @@ done
 
 # If we have more CPUs than queues, then stripe CPUs across tx affinity
 # as CPUNumber % queue_count.
-# Be aware, striping CPUs across tx queue may not yield best throughput. In that case, only affilliate
-# the CPUs handling tx TRQ to the coresponding tx queue, leave rest of CPUs alone.
+# Be aware, striping CPUs across TX queues may not yield best throughput. In that case, only affilliate
+# the CPUs handling TX IRQ to the corresponding TX queue, leave rest of CPUs alone.
 for q in $XPS; do
   queue_re=".*tx-([0-9]+).*$"
   if [[ "$q" =~ ${queue_re} ]]; then


### PR DESCRIPTION
In our test on xps_cpus setting, we had all CPUs striped across TX queues  in the driver by default, however it resulted in throughput  degradation.  It had to revert back to only setting the CPUs which handles TX irq.