### PR TITLE
set hostname: consider fully qualified static hostname

### DIFF
--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -40,14 +40,15 @@ fi
 #     a FQDN that is > 64 bytes.
 #
 # As a result, we set the host name whenever a new host name is set - ignoring when
-# old_fqdn is equal to new_host_name, to the truncated unqualified domain name.
+# old_hostname is equal to new_host_name's host part, to the truncated unqualified
+# domain name.
 
 hostnamecli=$(which hostname 2> /dev/null)
 if [ -x "$hostnamecli" ]; then
-  old_fqdn=$($hostnamecli -f)
+  old_hostname=$($hostnamecli)
 fi
 
-if [ -n "$new_host_name" ] && [ "$new_host_name" != "$old_fqdn" ] && ! echo "$new_host_name" | grep -iq "metadata.google.internal"; then
+if [ -n "$new_host_name" ] && [ "${new_host_name%%.*}" != "$old_hostname" ] && ! echo "$new_host_name" | grep -iq "metadata.google.internal"; then
   hostname "${new_host_name%%.*}"
 
   # If NetworkManager is installed set the hostname with nmcli.


### PR DESCRIPTION
The guest system may have its static hostname set with fully qualified hostname, this change make sure to only reset hostname if the static hostname is not fully qualified name and is different to the truncated new_host_name.