### PR TITLE
Fix `warning: command substitution: ignored null byte in input`

### DIFF
--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -58,7 +58,7 @@ function err() {
 #######################################
 function get_namespace_device_name() {
   local nvme_json
-  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r)"
+  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r | tr -d '\0')"
   if [[ $? -ne 0 ]]; then
     return 1
   fi


### PR DESCRIPTION
This is to remove safe warning when running `google_nvme_id`:
```
]# bash /usr/lib/udev/google_nvme_id -d /dev/nvme0n1
/usr/lib/udev/google_nvme_id: line 65: warning: command substitution: ignored null byte in input
ID_SERIAL_SHORT=persistent-disk-0
ID_SERIAL=Google_PersistentDisk_persistent-disk-0

]# nvme_json="$(/usr/sbin/nvme id-ns -b /dev/nvme0n1 | cut -b 384-)"
-bash: warning: command substitution: ignored null byte in input
]# nvme_json="$(/usr/sbin/nvme id-ns -b /dev/nvme0n1 | cut -b 384- | tr -d '\0')"
<no warning>
```
Refer to https://bugzilla.redhat.com/show_bug.cgi?id=1473642