### PR TITLE
src/lib/udev: only create symlinks for GCP devices

### DIFF
--- a/src/lib/udev/rules.d/65-gce-disk-naming.rules
+++ b/src/lib/udev/rules.d/65-gce-disk-naming.rules
@@ -20,6 +20,11 @@ SUBSYSTEM!="block", GOTO="gce_disk_naming_end"
 # SCSI naming
 KERNEL=="sd*|vd*", IMPORT{program}="scsi_id --export --whitelisted -d $tempnode"
 
+# Don't symlink if it's not our devices. This is a fail-safe against these rules
+# running outside of GCP.
+KERNEL=="sd*|vd*", ENV{ID_VENDOR}!="Google", GOTO="gce_disk_naming_end"
+KERNEL=="nvme*", ATTRS{model}!="nvme_card*", GOTO="gce_disk_naming_end"
+
 # NVME Local SSD naming
 KERNEL=="nvme*n*", ATTRS{model}=="nvme_card", PROGRAM="/bin/sh -c 'nsid=$$(echo %k|sed -re s/nvme[0-9]+n\([0-9]+\).\*/\\1/); echo $$((nsid-1))'", ENV{ID_SERIAL_SHORT}="local-nvme-ssd-%c"
 KERNEL=="nvme*", ATTRS{model}=="nvme_card", ENV{ID_SERIAL}="Google_EphemeralDisk_$env{ID_SERIAL_SHORT}"


### PR DESCRIPTION
We would like to ship these rules in Fedora CoreOS and RHEL CoreOS. In these image-based systems, we ship the exact same content to cloud and bare metal platforms alike.

The way these rules are written currently, they assume that the host is running in GCP and so create symlinks for all SCSI and NVMe disks and partitions. This conflicts with our image model.

We could play some tricks on the OS side so that the rules are only activated in GCP, but it would be simpler if they were written in the first place to tolerate running outside GCP.

Even on traditional Linux distros, users may mistakenly install the package containing these rules and be surprised to find `google` symlinks show up.

Tweak the rules to skip symlinking if it's not a Google device.

For SCSI disks, we can rely on the `ID_VENDOR` property.

For NVMe disks, we key off of the model matching `nvme_card*`. The model name appears generic, but is in fact so generic that it appears to be specific to GCP. (A Google search for "nvme_card" returns 10 results, most of which relate to GCP. Ironically, it includes a GCP RFE[[1]] to have a less generic model name.)

Anyway, this is how the existing rules already identify NVMe devices today, so another way to look at this is that we're just excluding the set of NVMe devices that our rules don't care about.

[1]: https://issuetracker.google.com/issues/35904971