### PR TITLE
dracut: Add a new dracut module for gcp udev rules

### DIFF
--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+%global dracutdir %(pkg-config --variable=dracutdir dracut)
+
 # For EL7, if building on CentOS, override dist to be el7.
 %if 0%{?rhel} == 7
   %define dist .el7
@@ -49,8 +51,11 @@ cp -a src/{etc,usr} %{buildroot}
 install -d %{buildroot}/%{_udevrulesdir}
 cp -a src/lib/udev/rules.d/* %{buildroot}/%{_udevrulesdir}
 cp -a src/lib/udev/google_nvme_id %{buildroot}/%{_udevrulesdir}/../
+install -d  %{buildroot}/%{dracutdir}
+cp -a src/lib/dracut/* %{buildroot}/%{dracutdir}/
 
 %files
+%attr(0755,-,-) /usr/lib/dracut/modules.d/30gcp-udev-rules/module-setup.sh
 %defattr(0644,root,root,0755)
 %attr(0755,-,-) %{_bindir}/*
 %attr(0755,-,-) /etc/dhcp/dhclient.d/google_hostname.sh

--- a/src/lib/dracut/modules.d/30gcp-udev-rules/module-setup.sh
+++ b/src/lib/dracut/modules.d/30gcp-udev-rules/module-setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+# Install 65-gce-disk-naming.rules and
+# google_nvme_id into the initramfs
+
+# called by dracut
+install() {
+  inst_multiple nvme grep sed
+  inst_simple /usr/lib/udev/google_nvme_id
+  inst_simple /usr/lib/udev/rules.d/65-gce-disk-naming.rules
+}
+
+installkernel() {
+  instmods nvme
+}


### PR DESCRIPTION
 - The dracut module is required for ignition (https://github.com/coreos/ignition) to work when using Redhat/Fedora CoreOS in GCP. Since the rules are kept in this repository, makes sense for the module to be part of it as well for a better maintenance in case the rules change;
 - Modify the spec file to include the new dracut module.