### PR TITLE
Revert "Replace `xxd` to `cut` for google_nvme_id (#49)"

### DIFF
--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -58,7 +58,7 @@ function err() {
 #######################################
 function get_namespace_device_name() {
   local nvme_json
-  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | cut -b 384-)"
+  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r)"
   if [[ $? -ne 0 ]]; then
     return 1
   fi


### PR DESCRIPTION
This reverts commit 512f7af07185041c604c3b6d9cf9ceccb5630c7d.

The migration from xxd to cut broke some distros i.e debian. The migration is either incorrect or backward incompatible.