### PR TITLE
debian packaging: add xxd dependency

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -11,6 +11,7 @@ Architecture: all
 Depends: google-compute-engine-oslogin,
          google-guest-agent,
          nvme-cli,
+         xxd,
          ${misc:Depends}
 Recommends: rsyslog | system-log-daemon
 Provides: irqbalance


### PR DESCRIPTION
Add xxd dependency to debian packaging since google_nvme_id script has a runtime dependency to it.