### PR TITLE
Replace xxd with dd for google_nvme_id

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -11,7 +11,6 @@ Architecture: all
 Depends: google-compute-engine-oslogin,
          google-guest-agent,
          nvme-cli,
-         xxd,
          ${misc:Depends}
 Recommends: rsyslog | system-log-daemon
 Provides: irqbalance

--- a/src/lib/udev/google_nvme_id
+++ b/src/lib/udev/google_nvme_id
@@ -58,7 +58,7 @@ function err() {
 #######################################
 function get_namespace_device_name() {
   local nvme_json
-  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | xxd -p -seek 384 | xxd -p -r)"
+  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | dd bs=1 skip=384 2>/dev/null)"
   if [[ $? -ne 0 ]]; then
     return 1
   fi


### PR DESCRIPTION
Replace xxd with dd for google_nvme_id
`google_nvme_id` script currently uses `xxd` to parse nvme device
info, but we need to install additional package `xxd` for fedora,
`vim-common` and `vim-filesystem` for centos (or rhel) before
using it. Replace it with `dd` and we do not need to install
additional packages.

See https://github.com/coreos/fedora-coreos-config/pull/2412 (comment)

We initially tried to replace it with cut, creating a different
result than expected.
See: https://github.com/GoogleCloudPlatform/guest-configs/pull/49 Discussion  about the use of `dd`vs `cut`.

Tests for Fedora CoreOS:
```
nvme id-ns -b /dev/nvme0n1 | xxd -p --seek 384 | xxd -p -r | od -x
0000000 227b 6564 6976 6563 6e5f 6d61 2265 223a
0000020 6570 7372 7369 6574 746e 642d 7369 2d6b
0000040 2230 222c 6964 6b73 745f 7079 2265 223a
0000060 4550 5352 5349 4554 544e 7d22 0000 0000
0000100 0000 0000 0000 0000 0000 0000 0000 0000
*
0007200

nvme id-ns -b /dev/nvme0n1 | dd bs=1 skip=384 2>/dev/null  | od -x
0000000 227b 6564 6976 6563 6e5f 6d61 2265 223a
0000020 6570 7372 7369 6574 746e 642d 7369 2d6b
0000040 2230 222c 6964 6b73 745f 7079 2265 223a
0000060 4550 5352 5349 4554 544e 7d22 0000 0000
0000100 0000 0000 0000 0000 0000 0000 0000 0000
*
0007200
```
Tests for Debian  12
```
nvme id-ns -b /dev/nvme0n1 | dd bs=1 skip=384 2>/dev/null  | od -x
0000000 227b 6564 6976 6563 6e5f 6d61 2265 223a
0000020 6f6c 6163 2d6c 766e 656d 732d 6473 312d
0000040 2c22 6422 7369 5f6b 7974 6570 3a22 4c22
0000060 434f 4c41 535f 4453 7d22 0000 0000 0000
0000100 0000 0000 0000 0000 0000 0000 0000 0000
*
0007200

nvme id-ns -b /dev/nvme0n1 | dd bs=1 skip=384 2>/dev/null  | od -x
0000000 227b 6564 6976 6563 6e5f 6d61 2265 223a
0000020 6f6c 6163 2d6c 766e 656d 732d 6473 312d
0000040 2c22 6422 7369 5f6b 7974 6570 3a22 4c22
0000060 434f 4c41 535f 4453 7d22 0000 0000 0000
0000100 0000 0000 0000 0000 0000 0000 0000 0000
*
0007200
```