### PR TITLE
Add the ability to signal the guest-agent's network events socket to google_set_hostname.sh

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -11,6 +11,7 @@ Architecture: all
 Depends: google-compute-engine-oslogin,
          google-guest-agent,
          nvme-cli,
+         networkd-dispatcher,
          ${misc:Depends}
 Recommends: rsyslog | system-log-daemon
 Provides: irqbalance

--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -85,3 +85,4 @@ fi
 
 %post
 dracut --force
+

--- a/src/etc/sysconfig/network/scripts/google_up.sh
+++ b/src/etc/sysconfig/network/scripts/google_up.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2024 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+google_guest_agent sendcmd '{"Command":"agent.hostname.reconfigurehostname"}'

--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -13,6 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This file previously handled setting the hostname. This functionality and the
+# ability to configure it has been moved to the guest-agent. This script retains
+# legacy behavior in some cases for compatibility.
+
+retain_legacy_behavior() {
+	# Don't retain legacy behavior if set_hostname or set_fqdn has been enabled in
+	# the agent.
+	if google_guest_agent sendcmd '{"Command":"agent.config.getoption","Option":"Unstable.SetHostname"}' | grep '"Value":"true"' >/dev/null || google_guest_agent sendcmd '{"Command":"agent.config.getoption","Option":"Unstable.SetFqdn"}' | grep -i '"Value":"true"' >/dev/null; then
+		return 1
+	fi
+	return 0
+}
+
+if ! retain_legacy_behavior;then
+	exec google_guest_agent sendcmd '{"Command":"agent.hostname.reconfigurehostname"}'
+fi
+
 # Deal with a new hostname assignment.
 
 if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then

--- a/src/usr/lib/networkd-dispatcher/routable.d/google_routable.sh
+++ b/src/usr/lib/networkd-dispatcher/routable.d/google_routable.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright 2023 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+google_guest_agent sendcmd '{"Command":"agent.hostname.reconfigurehostname"}'


### PR DESCRIPTION
When this script is called via its old name and it detects that both hostname and fqdn management are disabled in the guest-agent, it will retain legacy behavior.

This is part of handling hostname and FQDN setting in the guest-agent rather than the guest configs. The new architecture is that the user can configure the desired behavior regarding hostnames and FQDNs from the guest-agent, and the guest-configs signal to the guest-agent that some event on the system (such as an interface coming up) has happened.

The google_set_hostname script (with a new symlink under the name google_guest_agent_netevent) is used for triggering these events, the other scripts included here are hook scripts called by various networking stacks to send this signal.

 * /etc/dhcp/dhclient.d/google_hostname.sh:
Distros: Enterprise Linux, Debian 10/11
Networking Stacks: dhclient, NetworkManager
The original architecture consisted of this dhclient exit hook calling the google_set_hostname script with arguments, now it calls the script to send the iface-up event. This hook is still used directly on debian 10 and 11 by dhclient. It is called indirectly by a compatibility script to call dhclient exit hooks from NetworkManager-dispatcher on enterprise linux.

* /etc/sysconfig/network/scripts/google_up.sh
Distros: SUSE
Network Stacks: wicked
This new script requires an associated config toggle in /etc/sysconfig/network/config to enable this script (POST_UP_SCRIPT="compat:suse:google_up.sh"). Unfortunately there is no way for packages to drop in configuration files either through /etc/sysconfig/network or /etc/wicked, so this line is appended in a post-install script.

* /usr/lib/networkd-dispatcher
Distros: Debian 12, Ubuntu
Network Stacks: systemd-networkd
This script is called when interfaces configured by systemd-networkd are routable. No additional configuration required, simply drop the script in the right folder.