### PR TITLE
extract rsyslog service name with a regexp for valid systemd unit names

### DIFF
--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -62,7 +62,8 @@ if [ -n "$new_host_name" ] && [ "${new_host_name%%.*}" != "$old_hostname" ] && !
   # Restart rsyslog to update the hostname.
   systemctl=$(which systemctl 2> /dev/null)
   if [ -x "$systemctl" ]; then
-    hasrsyslog=$($systemctl | grep rsyslog | cut -f1 -d' ')
+	# See man 5 systemd.unit for systemd unit naming rules
+    hasrsyslog=$($systemctl | grep rsyslog | grep -oE '[a-zA-Z0-9:-_.\]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)')
     if [ ! -z "$hasrsyslog" ]; then
       $systemctl -q --no-block restart "$hasrsyslog"
     fi


### PR DESCRIPTION
fixes #66 

The regexp is obviously overkill but it's correct and it makes zero new assumptions about what rsyslog looks like on the host. The current method of `grep rsyslog | cut -f1 -d' '` has a lot of edge cases, I don't want to find out later that there's some obscure setup we broke by assuming that everything is named `rsyslog.service`.

/cc @dorileo @zmarano 