### PR TITLE
Add hostname hook for NetworkManager without dhclient compat script

### DIFF
--- a/packaging/debian/install
+++ b/packaging/debian/install
@@ -2,6 +2,7 @@ etc/apt/apt.conf.d/*
 etc/modprobe.d/*
 etc/rsyslog.d/*
 etc/sysctl.d/*
+etc/NetworkManager/dispatcher.d/*
 lib/udev/rules.d/*
 lib/udev/*
 usr/bin/*

--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -59,6 +59,7 @@ cp -a src/lib/dracut/* %{buildroot}/%{dracutdir}/
 %defattr(0644,root,root,0755)
 %attr(0755,-,-) %{_bindir}/*
 %attr(0755,-,-) /etc/dhcp/dhclient.d/google_hostname.sh
+%attr(0755,-,-) /etc/NetworkManager/dispatcher.d/google_hostname.sh
 %{_udevrulesdir}/*
 %attr(0755,-,-) %{_udevrulesdir}/../google_nvme_id
 %config /etc/dracut.conf.d/*

--- a/src/etc/NetworkManager/dispatcher.d/google_hostname.sh
+++ b/src/etc/NetworkManager/dispatcher.d/google_hostname.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2024 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+if [[ $2 == "up" ]]; then
+	new_host_name=$DHCP4_HOST_NAME new_ip_address=${DHCP4_IP_ADDRESS%%/*} google_set_hostname
+fi
+


### PR DESCRIPTION
This compat script is no longer shippped in newer versions of EL9. Tested with both scripts on the same system and the second execution just overrides the first with the same (still correct) data.

This will affect other distros that use network manager too but I don't think this should be a problem. IPv4 support only, but we can fix this later.

/cc @dorileo 

Fixes #69 