### PR TITLE
Update is_a3_platform to include A3-edge shape

### DIFF
--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -105,7 +105,8 @@ function is_a3_platform() {
 
   [[ "$machine_type" == *"a3-highgpu-8g"* \
   || "$machine_type" == *"a3-ultragpu-8g"* \
-  || "$machine_type" == *"a3-megagpu-8g"* ]] || return 1
+  || "$machine_type" == *"a3-megagpu-8g"* \
+  || "$machine_type" == *"a3-edge-8g"* ]] || return 1
 
   return 0
 }


### PR DESCRIPTION
Update `is_a3_platform` to identify A3-edge shape to apply `google_set_multiqueue` on a3-edge VMs.