### PR TITLE
 Call google_set_hostname on openSUSE and when the agent is configured to manage hostname and FQDN, let it.

### DIFF
--- a/src/etc/sysconfig/network/scripts/google_up.sh
+++ b/src/etc/sysconfig/network/scripts/google_up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+new_host_name=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/hostname)
+new_ip_address=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/ip)
+new_ip_address=$new_ip_address new_host_name=$new_host_name google_set_hostname

--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -15,6 +15,30 @@
 
 # Deal with a new hostname assignment.
 
+# Legacy behavior is this script setting the hostname and fqdn directly.
+# New behavior is to notify the agent when they should be updated.
+#
+# New behavior should be used (and this function returns 1) when the agent
+# is new enough to include the ggactl utility and the agent configuration
+# enables the SetFQDN or SetHostname options
+retain_legacy_behavior() {
+	ggactl=$(which ggactl 2> /dev/null)
+	if [ -z "$ggactl" ]; then
+		# Agent doesn't have ggactl for communication, legacy behavior.
+		return 0
+	fi
+	# Don't retain legacy behavior if set_hostname or set_fqdn is enabled in
+	# the agent.
+	if ggactl coreplugin send '{"Command":"agent.config.getoption","Option":"Unstable.SetHostname"}' | grep '"Value":"true"' >/dev/null || ggactl coreplugin send '{"Command":"agent.config.getoption","Option":"Unstable.SetFQDN"}' | grep -i '"Value":"true"' >/dev/null; then
+		return 1
+	fi
+	return 0
+}
+
+if ! retain_legacy_behavior; then
+	exec ggactl coreplugin send '{"Command":"agent.hostname.reconfigurehostname"}'
+fi
+
 if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
   # Delete entries with new_host_name or new_ip_address in /etc/hosts.
   sed -i"" '/Added by Google/d' /etc/hosts


### PR DESCRIPTION
/cc