### PR TITLE
Fix the name for A3 Edge VMs

### DIFF
--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -106,7 +106,7 @@ function is_a3_platform() {
   [[ "$machine_type" == *"a3-highgpu-8g"* \
   || "$machine_type" == *"a3-ultragpu-8g"* \
   || "$machine_type" == *"a3-megagpu-8g"* \
-  || "$machine_type" == *"a3-edge-8g"* ]] || return 1
+  || "$machine_type" == *"a3-edgegpu-8g"* ]] || return 1
 
   return 0
 }


### PR DESCRIPTION
This is required to enable IRQ spread for both `a3-edgegpu-8g` and `a3-edgegpu-8g-nolssd` VMs.