### PR TITLE
Always use IP from primary NIC in the networkd-dispatcher routable hook

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -12,6 +12,7 @@ Depends: google-compute-engine-oslogin,
          google-guest-agent,
          nvme-cli,
          networkd-dispatcher,
+         jq,
          ${misc:Depends}
 Recommends: rsyslog | system-log-daemon
 Provides: irqbalance

--- a/packaging/ubuntu/control
+++ b/packaging/ubuntu/control
@@ -15,6 +15,7 @@ Depends: ${misc:Depends},
          google-compute-engine-oslogin (>> 20190801),
          google-guest-agent,
          nvme-cli,
+         jq,
          ${misc:Depends}
 Provides: irqbalance
 Recommends: rsyslog | system-log-daemon

--- a/src/etc/sysconfig/network/scripts/google_up.sh
+++ b/src/etc/sysconfig/network/scripts/google_up.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-new_host_name=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/hostname)
-new_ip_address=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/ip)
+instance=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/?recursive=true)
+new_ip_address=$(jq -r .networkInterfaces[0].ip <<< $instance)
+new_host_name=$(jq -r .hostname <<< $instance)
 new_ip_address=$new_ip_address new_host_name=$new_host_name google_set_hostname

--- a/src/usr/lib/networkd-dispatcher/routable.d/google_hostname.sh
+++ b/src/usr/lib/networkd-dispatcher/routable.d/google_hostname.sh
@@ -12,9 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-if [[ $(jq .State <<< $json) == *"unmanaged"* ]]; then
-	exit 0
-fi
-new_host_name=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/hostname)
-new_ip_address=$ADDR new_host_name=$new_host_name google_set_hostname
+instance=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/?recursive=true)
+new_ip_address=$(jq -r .networkInterfaces[0].ip <<< $instance) new_host_name=$(jq -r .hostname <<< $instance) google_set_hostname
 

--- a/src/usr/lib/networkd-dispatcher/routable.d/google_hostname.sh
+++ b/src/usr/lib/networkd-dispatcher/routable.d/google_hostname.sh
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-
+if [[ $(jq .State <<< $json) == *"unmanaged"* ]]; then
+	exit 0
+fi
 new_host_name=$(curl -H 'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/hostname)
 new_ip_address=$ADDR new_host_name=$new_host_name google_set_hostname
 


### PR DESCRIPTION
This will skip executing hooks for interfaces that systemd-networkd knows about but doesn't manage, such as docker's. Adds a dependency on `jq`, if we really don't want to take a new dependency we can do something like  `grep -oE '\"[Ss]tate\"\s*:\s*"[^"]*"'` but it's a bit brittle and relies on the json not changing very much.

/cc @dorileo @ChaitanyaKulkarni28 @drewhli 
/hold