### PR TITLE
Update google_set_multiqueue to enable on A3Ultra family

### DIFF
--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -106,7 +106,8 @@ function is_a3_platform() {
   [[ "$machine_type" == *"a3-highgpu-8g"* \
   || "$machine_type" == *"a3-ultragpu-8g"* \
   || "$machine_type" == *"a3-megagpu-8g"* \
-  || "$machine_type" == *"a3-edgegpu-8g"* ]] || return 1
+  || "$machine_type" == *"a3-edgegpu-8g"* \
+  || "$machine_type" == *"a3-ultragpu-"* ]] || return 1
 
   return 0
 }


### PR DESCRIPTION
Update is_a3_platform to identify a3-ultragpu-* shapes to apply google_set_multiqueue on A3Ultra VMs.