### PR TITLE
Depend on jq in enterprise linux

### DIFF
--- a/packaging/google-compute-engine.spec
+++ b/packaging/google-compute-engine.spec
@@ -33,6 +33,7 @@ Requires: google-compute-engine-oslogin
 Requires: google-guest-agent
 Requires: rsyslog
 Requires: nvme-cli
+Requires: jq
 
 BuildArch: noarch
 


### PR DESCRIPTION
If users switch to wicked or systemd-networkd on these systems they will need it. No impact by default.

/cc @ChaitanyaKulkarni28 @dorileo @drewhli 