### PR TITLE
Update google_set_multiqueue to skip set_irq if nic is not a gvnic device

### DIFF
--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -106,7 +106,8 @@ function is_a3_platform() {
   [[ "$machine_type" == *"a3-highgpu-8g"* \
   || "$machine_type" == *"a3-ultragpu-8g"* \
   || "$machine_type" == *"a3-megagpu-8g"* \
-  || "$machine_type" == *"a3-edgegpu-8g"* ]] || return 1
+  || "$machine_type" == *"a3-edgegpu-8g"* \
+  || "$machine_type" == *"a3-ultragpu-"* ]] || return 1
 
   return 0
 }

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -17,7 +17,6 @@
 # processor 0. For this virtionet configuration, distributing IRQs to all
 # processors results in comparatively high cpu utilization and comparatively
 
-
 # low network bandwidth.
 #
 # For a multi-queue / MSI-X virtionet device, sets the IRQ affinities to the

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -119,7 +119,8 @@ function is_gvnic() {
   local -r nic_name="$1"
   driver_type=$(ethtool -i $nic_name | grep driver)
 
-  [[ "$driver_type" == *"gve"* ]] || return 1
+  [[ "$driver_type" == *"gve"* 
+  || "$driver_type" == *"gvnic"* ]] || return 1
 
   return 0
 }

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -112,7 +112,19 @@ function is_a3_platform() {
   return 0
 }
 
-echo "Running $(basename $0)."
+
+# returns 0 (success) if the supplied nic is a Gvnic device.
+function is_gvnic() {
+  local -r nic_name="$1"
+  driver_type=$(ethtool -i $nic_name | grep driver)
+
+  [[ "$driver_type" == *"gve"* ]] || return 1
+
+  return 0
+}
+
+# echo "Running $(basename $0)."
+
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
 
 # Loop through all the virtionet devices and enable multi-queue
@@ -126,7 +138,10 @@ if [ -x "$(command -v ethtool)" ]; then
         continue
       fi
       num_max_channels=$(ethtool -l "$eth_dev" | grep -m 1 Combined | cut -f2)
-      [ "${num_max_channels}" -eq "1" ] && continue
+      if [[ -n "${num_max_channels}" || "${num_max_channels}" -eq "1" ]]; then
+        echo "num_max_channels is n/a, skipping set channels for $eth_dev"
+        continue
+      fi
       if is_decimal_int "$num_max_channels" && \
         set_channels "$eth_dev" "$num_max_channels"; then
         echo "Set channels for $eth_dev to $num_max_channels."
@@ -256,6 +271,13 @@ fi
 # IRQ binding for numa 0, CPUs [0, 51] and [104, 155] are for numa 0.
 numa0_irq_start=1
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  if ! is_gvnic "$nic_name"; then
+    echo "$nic_name is not gvnic device, skipping set irq on this device"
+    continue
+  fi
+
+  echo "$nic_name is Gvnic device, continuing set IRQ on $nic_name ."
+
   nic_numa_node=$(cat /sys/class/net/"$nic_name"/device/numa_node)
   if [[ $nic_numa_node -ne 0 ]]; then
     continue
@@ -278,6 +300,13 @@ done
 # IRQ binding for numa 1, CPUs [52, 103] and [156, 207] are for numa 1.
 numa1_irq_start=52
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  if ! is_gvnic "$nic_name"; then
+    echo "$nic_name is not gvnic device, skipping set irq on this device"
+    continue
+  fi
+
+  echo "$nic_name is Gvnic device, continuing set IRQ on $nic_name ."
+
   nic_numa_node=$(cat /sys/class/net/"$nic_name"/device/numa_node)
   if [[ $nic_numa_node -ne 1 ]]; then
     continue
@@ -296,3 +325,4 @@ find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | so
 
   numa1_irq_start=$bind_cores_end
 done
+  

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -123,8 +123,7 @@ function is_gvnic() {
   return 0
 }
 
-# echo "Running $(basename $0)."
-
+echo "Running $(basename $0)."
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
 
 # Loop through all the virtionet devices and enable multi-queue

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -271,6 +271,7 @@ fi
 # IRQ binding for numa 0, CPUs [0, 51] and [104, 155] are for numa 0.
 numa0_irq_start=1
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  # For non-gvnic devices (e.g. mlx5), the IRQ bindings will be handled by the device's driver.
   if ! is_gvnic "$nic_name"; then
     echo "$nic_name is not gvnic device, skipping set irq on this device"
     continue
@@ -300,6 +301,7 @@ done
 # IRQ binding for numa 1, CPUs [52, 103] and [156, 207] are for numa 1.
 numa1_irq_start=52
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  # For non-gvnic devices (e.g. mlx5), the IRQ bindings will be handled by the device's driver.
   if ! is_gvnic "$nic_name"; then
     echo "$nic_name is not gvnic device, skipping set irq on this device"
     continue


### PR DESCRIPTION
On A3Ultra and A4 platforms, we will want to skip setting IRQ binding on non-gvnic devices as there will be a mixture of GVE and Mellanox drivers. This PR introduces a `is_gvnic` method which determines if the nic is gvnic or not by using the `ethtool -i <interface>` command.