### PR TITLE
gce-nic-naming: exit 1 so that udev ignores the rule on error

### DIFF
--- a/src/usr/bin/gce-nic-naming
+++ b/src/usr/bin/gce-nic-naming
@@ -42,22 +42,16 @@ declare -i accelerator_to_ethernet_ratio=1
 logger -t "gce-nic-naming" -p local0.info "Run ${LOG_TAG}"
 
 ###############################
-# Log error and exit with -1
+# Log error and exit with 1
 # Environment:
-#   ID_NET_NAME_PATH: net_id name based off of PCI path in form enp##s#
 # Arguments:
 #   $1: Error message
 ###############################
 function error_and_exit() {
   # Default to the network name if it exists.
-  # If script is run and returns empty or invalid name, UDev defaults to normal
-  # name the system would create as if this rule does not exist.
-  echo "$ID_NET_NAME_PATH"
   err "$@"
-  logger -t "${LOG_TAG}" -p local0.notice \
-    "Defaulting to name: ${ID_NET_NAME_PATH}"
-  # Script must exit with 0 or rule will be ignored.
-  exit 0
+  # Exit with non-zero code so that udev ignores this rule.
+  exit 1
 }
 
 ###############################


### PR DESCRIPTION
An issue with the prior behavior is that on error, we assume it is OK to use the predictable NIC name rather than allowing udev to decide what the fallback would be. When a guest configures "ethX" names and this script exits with errors, the ethX configuration is ignoring. This is particularly relevant in situations such as c3metal where we expect the script to error because we have an IDPF NIC but no accelerator devices.

/cc @dorileo @ChaitanyaKulkarni28 