### PR TITLE
Update google_set_multiqueue to configure vCPU ranges based on VM platform

### DIFF
--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -106,7 +106,8 @@ function is_a3_platform() {
   [[ "$machine_type" == *"a3-highgpu-8g"* \
   || "$machine_type" == *"a3-ultragpu-8g"* \
   || "$machine_type" == *"a3-megagpu-8g"* \
-  || "$machine_type" == *"a3-edgegpu-8g"* ]] || return 1
+  || "$machine_type" == *"a3-edgegpu-8g"* \
+  || "$machine_type" == *"a3-ultragpu-"* ]] || return 1
 
   return 0
 }

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -177,7 +177,8 @@ function get_vcpu_ranges_on_accelerator_platform {
 
 echo "Running $(basename $0)."
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
-IS_A3_PLATFORM=$(is_a3_platform)
+is_a3_platform
+IS_A3_PLATFORM=$?
 
 # Loop through all the virtionet devices and enable multi-queue
 if [ -x "$(command -v ethtool)" ]; then
@@ -266,7 +267,7 @@ num_cpus=$(nproc)
 num_queues=0
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if $IS_A3_PLATFORM && ! is_gvnic "$interface"; then
+  if [[ $IS_A3_PLATFORM ]] && ! $(is_gvnic "$interface"); then
     continue
   fi
   num_queues=$((num_queues + 1))
@@ -276,7 +277,7 @@ done
 # as CPUNumber % queue_count.
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if $IS_A3_PLATFORM && ! is_gvnic "$interface"; then
+  if [[ $IS_A3_PLATFORM ]] && ! $(is_gvnic "$interface"); then
     continue
   fi
 
@@ -306,7 +307,7 @@ for q in $XPS; do
   printf "Queue %d XPS=%s for %s\n" $queue_num `cat $q` $q
 done | sort -n -k2
 
-if ! $IS_A3_PLATFORM; then
+if [[ ! $IS_A3_PLATFORM ]]; then
   exit
 fi
 

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -130,6 +130,13 @@ function is_gvnic() {
 # numa1_irq_start_1, numa1_irq_end_1, numa1_irq_start_2, numa1_irq_end_2]
 # this will only return the vCPU ranges on NUMA0 and NUMA1 since accelerator
 # platforms of GEN3 and after only have 2 NUMA nodes.
+# The expected vCPU ranges on eahc platforms are:
+# A3/A3-mega: 
+# numa0: [0, 51] [104, 155]
+# numa1: [52, 103] [156, 207]
+# A3-ultra:
+# numa0: [0, 55] [113, 168]
+# numa1: [56, 112] [169, 224]
 function get_vcpu_ranges_on_accelerator_platform {
   declare -n arr_ref=$1
 
@@ -312,7 +319,6 @@ fi
 # enp134s0
 # enp140s0
 
-# IRQ binding for numa 0, CPUs [0, 51] and [104, 155] are for numa 0.
 irq_ranges=()
 get_vcpu_ranges_on_accelerator_platform irq_ranges
 echo "Binding vCPUs on NUMA0 [${irq_ranges[0]} ${irq_ranges[1]}], [${irq_ranges[2]} ${irq_ranges[3]}]}"
@@ -347,7 +353,6 @@ find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | so
   numa0_irq_start=$bind_cores_end
 done
 
-# IRQ binding for numa 1, CPUs [52, 103] and [156, 207] are for numa 1.
 numa1_irq_start=${irq_ranges[4]}
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
   # For non-gvnic devices (e.g. mlx5), the IRQ bindings will be handled by the device's driver.

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -17,7 +17,6 @@
 # processor 0. For this virtionet configuration, distributing IRQs to all
 # processors results in comparatively high cpu utilization and comparatively
 
-
 # low network bandwidth.
 #
 # For a multi-queue / MSI-X virtionet device, sets the IRQ affinities to the

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -177,7 +177,7 @@ function get_vcpu_ranges_on_accelerator_platform {
 
 echo "Running $(basename $0)."
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
-IS_A3_PLATFORM = is_a3_platform
+IS_A3_PLATFORM=$(is_a3_platform)
 
 # Loop through all the virtionet devices and enable multi-queue
 if [ -x "$(command -v ethtool)" ]; then

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -119,7 +119,8 @@ function is_gvnic() {
   local -r nic_name="$1"
   driver_type=$(ethtool -i $nic_name | grep driver)
 
-  [[ "$driver_type" == *"gve"* ]] || return 1
+  [[ "$driver_type" == *"gve"* 
+  || "$driver_type" == *"gvnic"* ]] || return 1
 
   return 0
 }

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -264,12 +264,21 @@ num_cpus=$(nproc)
 
 num_queues=0
 for q in $XPS; do
+  interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
+  if ! is_gvnic "$interface"; then
+    continue
+  fi
   num_queues=$((num_queues + 1))
 done
 
 # If we have more CPUs than queues, then stripe CPUs across tx affinity
 # as CPUNumber % queue_count.
 for q in $XPS; do
+  interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
+  if ! is_gvnic "$interface"; then
+    continue
+  fi
+
   queue_re=".*tx-([0-9]+).*$"
   if [[ "$q" =~ ${queue_re} ]]; then
     queue_num=${BASH_REMATCH[1]}

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -124,6 +124,24 @@ function is_gvnic() {
   return 0
 }
 
+# Returns the vCPU ranges on each of the numa nodes based on the platform.
+# The vCPU ranges will be in the form of array of
+# [numa0_irq_start_1, numa0_irq_end_1, numa0_irq_start_2, numa0_irq_end_2,
+# numa1_irq_start_1, numa1_irq_end_1, numa1_irq_start_2, numa1_irq_end_2]
+function get_vcpu_ranges {
+  declare -n arr_ref=$1
+  machine_type=$(curl -m 1 -H "Metadata-Flavor: Google" \
+    http://169.254.169.254/computeMetadata/v1/instance/machine-type)
+
+  if [[ "$machine_type" == *"a3-highgpu-8g"* \
+  || "$machine_type" == *"a3-megagpu-8g"* \
+  || "$machine_type" == *"a3-edgegpu-8g"* ]]; then
+    arr_ref=(1, 51, 104, 155, 52, 103, 156, 207)
+  elif [[ "$machine_type" == *"a3-ultragpu-"* ]]; then
+    arr_ref=(1, 55, 113, 168, 56, 112, 169, 224)
+  fi
+}
+
 echo "Running $(basename $0)."
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
 
@@ -269,7 +287,12 @@ fi
 # enp140s0
 
 # IRQ binding for numa 0, CPUs [0, 51] and [104, 155] are for numa 0.
-numa0_irq_start=1
+irq_ranges=()
+get_vcpu_ranges irq_ranges
+echo "Binding vCPUs on NUMA0 [${irq_ranges[0]} ${irq_ranges[1]}], [${irq_ranges[2]} ${irq_ranges[3]}]}"
+echo "Binding vCPUs on NUMA1 [${irq_ranges[4]} ${irq_ranges[5]}], [${irq_ranges[6]} ${irq_ranges[7]}]}"
+
+numa0_irq_start=${irq_ranges[0]}
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
   # For non-gvnic devices (e.g. mlx5), the IRQ bindings will be handled by the device's driver.
   if ! is_gvnic "$nic_name"; then
@@ -288,8 +311,8 @@ find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | so
   bind_cores_begin=$numa0_irq_start
   bind_cores_end=$((bind_cores_begin + nic_num_queues))
 
-  if [[ $bind_cores_begin -lt 51 ]] && [[ $bind_cores_end -gt 51 ]]; then
-    bind_cores_begin=104
+  if [[ $bind_cores_begin -lt ${irq_ranges[1]} ]] && [[ $bind_cores_end -gt ${irq_ranges[1]} ]]; then
+    bind_cores_begin=${irq_ranges[2]}
     bind_cores_end=$((bind_cores_begin + nic_num_queues))
   fi
 
@@ -299,7 +322,7 @@ find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | so
 done
 
 # IRQ binding for numa 1, CPUs [52, 103] and [156, 207] are for numa 1.
-numa1_irq_start=52
+numa1_irq_start=${irq_ranges[4]}
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
   # For non-gvnic devices (e.g. mlx5), the IRQ bindings will be handled by the device's driver.
   if ! is_gvnic "$nic_name"; then
@@ -318,8 +341,8 @@ find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | so
   bind_cores_begin=$numa1_irq_start
   bind_cores_end=$((bind_cores_begin + nic_num_queues))
 
-  if [[ $bind_cores_begin -lt 103 ]] && [[ $bind_cores_end -gt 103 ]]; then
-    bind_cores_begin=156
+  if [[ $bind_cores_begin -lt ${irq_ranges[5]} ]] && [[ $bind_cores_end -gt ${irq_ranges[5]} ]]; then
+    bind_cores_begin=${irq_ranges[6]}
     bind_cores_end=$((bind_cores_begin + nic_num_queues))
   fi
 

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -265,7 +265,7 @@ num_cpus=$(nproc)
 num_queues=0
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if ! is_gvnic "$interface"; then
+  if is_a3_platform && ! is_gvnic "$interface"; then
     continue
   fi
   num_queues=$((num_queues + 1))
@@ -275,7 +275,7 @@ done
 # as CPUNumber % queue_count.
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if ! is_gvnic "$interface"; then
+  if is_a3_platform && ! is_gvnic "$interface"; then
     continue
   fi
 

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -112,7 +112,19 @@ function is_a3_platform() {
   return 0
 }
 
-echo "Running $(basename $0)."
+
+# returns 0 (success) if the supplied nic is a Gvnic device.
+function is_gvnic() {
+  local -r nic_name="$1"
+  driver_type=$(ethtool -i $nic_name | grep driver)
+
+  [[ "$driver_type" == *"gve"* ]] || return 1
+
+  return 0
+}
+
+# echo "Running $(basename $0)."
+
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
 
 # Loop through all the virtionet devices and enable multi-queue
@@ -126,7 +138,10 @@ if [ -x "$(command -v ethtool)" ]; then
         continue
       fi
       num_max_channels=$(ethtool -l "$eth_dev" | grep -m 1 Combined | cut -f2)
-      [ "${num_max_channels}" -eq "1" ] && continue
+      if [[ -n "${num_max_channels}" || "${num_max_channels}" -eq "1" ]]; then
+        echo "num_max_channels is n/a, skipping set channels for $eth_dev"
+        continue
+      fi
       if is_decimal_int "$num_max_channels" && \
         set_channels "$eth_dev" "$num_max_channels"; then
         echo "Set channels for $eth_dev to $num_max_channels."
@@ -256,6 +271,13 @@ fi
 # IRQ binding for numa 0, CPUs [0, 51] and [104, 155] are for numa 0.
 numa0_irq_start=1
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  if ! is_gvnic "$nic_name"; then
+    echo "$nic_name is not gvnic device, skipping set irq on this device"
+    continue
+  fi
+
+  echo "$nic_name is Gvnic device, continuing set IRQ on $nic_name ."
+
   nic_numa_node=$(cat /sys/class/net/"$nic_name"/device/numa_node)
   if [[ $nic_numa_node -ne 0 ]]; then
     continue
@@ -278,6 +300,13 @@ done
 # IRQ binding for numa 1, CPUs [52, 103] and [156, 207] are for numa 1.
 numa1_irq_start=52
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  if ! is_gvnic "$nic_name"; then
+    echo "$nic_name is not gvnic device, skipping set irq on this device"
+    continue
+  fi
+
+  echo "$nic_name is Gvnic device, continuing set IRQ on $nic_name ."
+
   nic_numa_node=$(cat /sys/class/net/"$nic_name"/device/numa_node)
   if [[ $nic_numa_node -ne 1 ]]; then
     continue
@@ -296,3 +325,4 @@ find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | so
 
   numa1_irq_start=$bind_cores_end
 done
+  

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 #
@@ -177,6 +178,7 @@ function get_vcpu_ranges_on_accelerator_platform {
 
 echo "Running $(basename $0)."
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
+IS_A3_PLATFORM = is_a3_platform
 
 # Loop through all the virtionet devices and enable multi-queue
 if [ -x "$(command -v ethtool)" ]; then
@@ -265,7 +267,7 @@ num_cpus=$(nproc)
 num_queues=0
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if is_a3_platform && ! is_gvnic "$interface"; then
+  if $IS_A3_PLATFORM && ! is_gvnic "$interface"; then
     continue
   fi
   num_queues=$((num_queues + 1))
@@ -275,7 +277,7 @@ done
 # as CPUNumber % queue_count.
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if is_a3_platform && ! is_gvnic "$interface"; then
+  if $IS_A3_PLATFORM && ! is_gvnic "$interface"; then
     continue
   fi
 
@@ -305,7 +307,7 @@ for q in $XPS; do
   printf "Queue %d XPS=%s for %s\n" $queue_num `cat $q` $q
 done | sort -n -k2
 
-if ! is_a3_platform; then
+if ! $IS_A3_PLATFORM; then
   exit
 fi
 

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -123,8 +123,7 @@ function is_gvnic() {
   return 0
 }
 
-# echo "Running $(basename $0)."
-
+echo "Running $(basename $0)."
 VIRTIO_NET_DEVS=/sys/bus/virtio/drivers/virtio_net/virtio*
 
 # Loop through all the virtionet devices and enable multi-queue

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -155,7 +155,7 @@ function get_vcpu_ranges {
   "$numa0_irq_range0_start"
   "$numa0_irq_range0_end"
   "$numa0_irq_range1_start"
-  "$numa0_irq_range1_start"
+  "$numa0_irq_range1_end"
   "$numa1_irq_range0_start"
   "$numa1_irq_range0_end"
   "$numa1_irq_range1_start"

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -271,6 +271,7 @@ fi
 # IRQ binding for numa 0, CPUs [0, 51] and [104, 155] are for numa 0.
 numa0_irq_start=1
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  # For non-gvnic devices (e.g. mlx5), the IRQ bindings will be handled by the device's driver.
   if ! is_gvnic "$nic_name"; then
     echo "$nic_name is not gvnic device, skipping set irq on this device"
     continue
@@ -300,6 +301,7 @@ done
 # IRQ binding for numa 1, CPUs [52, 103] and [156, 207] are for numa 1.
 numa1_irq_start=52
 find /sys/class/net -type l | xargs -L 1 realpath | grep '/sys/devices/pci' | sort | xargs -L 1 basename | while read nic_name; do
+  # For non-gvnic devices (e.g. mlx5), the IRQ bindings will be handled by the device's driver.
   if ! is_gvnic "$nic_name"; then
     echo "$nic_name is not gvnic device, skipping set irq on this device"
     continue

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -124,25 +124,42 @@ function is_gvnic() {
   return 0
 }
 
-# Returns the vCPU ranges on each of the numa nodes based on the platform.
-# The vCPU ranges will be in the form of array of
+# Returns the vCPU ranges on each of the numa nodes. The vCPU ranges will
+# be in the form of array of
 # [numa0_irq_start_1, numa0_irq_end_1, numa0_irq_start_2, numa0_irq_end_2,
 # numa1_irq_start_1, numa1_irq_end_1, numa1_irq_start_2, numa1_irq_end_2]
 function get_vcpu_ranges {
   declare -n arr_ref=$1
-  machine_type=$(curl -m 1 -H "Metadata-Flavor: Google" \
-    http://169.254.169.254/computeMetadata/v1/instance/machine-type)
 
-  # Avoid binding on vCPU 0 since it is a heavily used CPU
-  # by the system.
+  # Get vCPU ranges for NUMA 0
+  numa0_irq_range=($(cat /sys/devices/system/node/node0/cpulist))
+  numa0_irq_range0="${numa0_irq_range[0]%,*}"
+  numa0_irq_range1="${numa0_irq_range[0]#*,}"
 
-  if [[ "$machine_type" == *"a3-highgpu-8g"* \
-  || "$machine_type" == *"a3-megagpu-8g"* \
-  || "$machine_type" == *"a3-edgegpu-8g"* ]]; then
-    arr_ref=(1, 51, 104, 155, 52, 103, 156, 207)
-  elif [[ "$machine_type" == *"a3-ultragpu-"* ]]; then
-    arr_ref=(1, 55, 113, 168, 56, 112, 169, 224)
-  fi
+  numa0_irq_range0_start=$(echo "$numa0_irq_range0" | cut -d '-' -f 1)
+  numa0_irq_range0_end=$(echo "$numa0_irq_range0" | cut -d '-' -f 2)
+  numa0_irq_range1_start=$(echo "$numa0_irq_range1" | cut -d '-' -f 1)
+  numa0_irq_range1_end=$(echo "$numa0_irq_range1" | cut -d '-' -f 2)
+
+  # Get vCPU ranges for NUMA 1
+  numa1_irq_range=($(cat /sys/devices/system/node/node1/cpulist))
+  numa1_irq_range0="${numa1_irq_range[0]%,*}"
+  numa1_irq_range1="${numa1_irq_range[0]#*,}"
+
+  numa1_irq_range0_start=$(echo "$numa1_irq_range0" | cut -d '-' -f 1)
+  numa1_irq_range0_end=$(echo "$numa1_irq_range0" | cut -d '-' -f 2)
+  numa1_irq_range1_start=$(echo "$numa1_irq_range1" | cut -d '-' -f 1)
+  numa1_irq_range1_end=$(echo "$numa1_irq_range1" | cut -d '-' -f 2)
+
+  arr_ref=(
+  "$numa0_irq_range0_start"
+  "$numa0_irq_range0_end"
+  "$numa0_irq_range1_start"
+  "$numa0_irq_range1_start"
+  "$numa1_irq_range0_start"
+  "$numa1_irq_range0_end"
+  "$numa1_irq_range1_start"
+  "$numa1_irq_range1_end")
 }
 
 echo "Running $(basename $0)."

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 #

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -128,7 +128,9 @@ function is_gvnic() {
 # be in the form of array of
 # [numa0_irq_start_1, numa0_irq_end_1, numa0_irq_start_2, numa0_irq_end_2,
 # numa1_irq_start_1, numa1_irq_end_1, numa1_irq_start_2, numa1_irq_end_2]
-function get_vcpu_ranges {
+# this will only return the vCPU ranges on NUMA0 and NUMA1 since accelerator
+# platforms of GEN3 and after only have 2 NUMA nodes.
+function get_vcpu_ranges_on_accelerator_platform {
   declare -n arr_ref=$1
 
   # Get vCPU ranges for NUMA 0
@@ -312,7 +314,7 @@ fi
 
 # IRQ binding for numa 0, CPUs [0, 51] and [104, 155] are for numa 0.
 irq_ranges=()
-get_vcpu_ranges irq_ranges
+get_vcpu_ranges_on_accelerator_platform irq_ranges
 echo "Binding vCPUs on NUMA0 [${irq_ranges[0]} ${irq_ranges[1]}], [${irq_ranges[2]} ${irq_ranges[3]}]}"
 echo "Binding vCPUs on NUMA1 [${irq_ranges[4]} ${irq_ranges[5]}], [${irq_ranges[6]} ${irq_ranges[7]}]}"
 

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -267,7 +267,7 @@ num_cpus=$(nproc)
 num_queues=0
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if [[ $IS_A3_PLATFORM ]] && ! $(is_gvnic "$interface"); then
+  if [[ $IS_A3_PLATFORM == 0 ]] && ! $(is_gvnic "$interface"); then
     continue
   fi
   num_queues=$((num_queues + 1))
@@ -277,7 +277,7 @@ done
 # as CPUNumber % queue_count.
 for q in $XPS; do
   interface=$(echo "$q" | grep -oP 'net/\K[^/]+')
-  if [[ $IS_A3_PLATFORM ]] && ! $(is_gvnic "$interface"); then
+  if [[ $IS_A3_PLATFORM == 0 ]] && ! $(is_gvnic "$interface"); then
     continue
   fi
 
@@ -307,7 +307,7 @@ for q in $XPS; do
   printf "Queue %d XPS=%s for %s\n" $queue_num `cat $q` $q
 done | sort -n -k2
 
-if [[ ! $IS_A3_PLATFORM ]]; then
+if [[ ! $IS_A3_PLATFORM == 0 ]]; then
   exit
 fi
 

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -137,6 +137,10 @@ function get_vcpu_ranges {
   numa0_irq_range1="${numa0_irq_range[0]#*,}"
 
   numa0_irq_range0_start=$(echo "$numa0_irq_range0" | cut -d '-' -f 1)
+  # Avoid setting binding IRQ on vCPU 0 as it is a busy vCPU being heavily
+  # used by the system.
+  numa0_irq_range0_start=$((numa0_irq_range0_start + 1))
+  
   numa0_irq_range0_end=$(echo "$numa0_irq_range0" | cut -d '-' -f 2)
   numa0_irq_range1_start=$(echo "$numa0_irq_range1" | cut -d '-' -f 1)
   numa0_irq_range1_end=$(echo "$numa0_irq_range1" | cut -d '-' -f 2)

--- a/src/usr/bin/google_set_multiqueue
+++ b/src/usr/bin/google_set_multiqueue
@@ -133,6 +133,9 @@ function get_vcpu_ranges {
   machine_type=$(curl -m 1 -H "Metadata-Flavor: Google" \
     http://169.254.169.254/computeMetadata/v1/instance/machine-type)
 
+  # Avoid binding on vCPU 0 since it is a heavily used CPU
+  # by the system.
+
   if [[ "$machine_type" == *"a3-highgpu-8g"* \
   || "$machine_type" == *"a3-megagpu-8g"* \
   || "$machine_type" == *"a3-edgegpu-8g"* ]]; then


### PR DESCRIPTION
For different VM platform the vCPU count is different so the vCPU ranges for IRQ binding will be also different, this PR introduces a `get_vcpu_ranges` method to get the vCPU ranges based from sys file instead of a hardcoded range.