### PR TITLE
Remove IDPF devices from renaming rules

### DIFF
--- a/src/lib/udev/rules.d/75-gce-network.rules
+++ b/src/lib/udev/rules.d/75-gce-network.rules
@@ -16,6 +16,3 @@ IMPORT{builtin}="net_id"
 
 # Rule to rename Mellanox devices
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlx5_core", PROGRAM="/usr/bin/gce-nic-naming", NAME="%c"
-
-# Rule to rename RDMA devices
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="idpf", PROGRAM="/usr/bin/gce-nic-naming", NAME="%c"

--- a/src/usr/bin/gce-nic-naming
+++ b/src/usr/bin/gce-nic-naming
@@ -21,8 +21,8 @@ readonly LOG_TAG=${LOG_TAG:-"gce-nic-naming_$$"}
 declare PCI_BUS_PATH='/sys/bus/pci/devices'
 declare SYS_PREPEND_PATH='/sys'
 # 0x15b3:0x101e is the vendor and device ID for Mellanox CX7
-# 0x8086:0x145c is the vendor and device ID for Intel IDPF
-readonly ETHERNET_DEVICES_VENDORS=('15b3:101e' '8086:145c')
+
+readonly ETHERNET_DEVICES_VENDORS=('15b3:101e')
 # 0x10de is the vendor ID for Nvidia
 readonly GPU_DEVICES_VENDORS=('10de' '10de')
 # PCI BUS ID path is in the format of 0000:00:04.0


### PR DESCRIPTION
IDPF is too broad a driver to trigger on so removing for the time being.