### PR TITLE
Avoid duplicate entries for the metadata server in /etc/hosts

### DIFF
--- a/src/usr/bin/google_set_hostname
+++ b/src/usr/bin/google_set_hostname
@@ -53,7 +53,10 @@ if [ -n "$new_host_name" ] && [ -n "$new_ip_address" ]; then
   fi
 
   # Add an entry for reaching the metadata server in /etc/hosts.
-  echo "169.254.169.254 metadata.google.internal  # Added by Google" >> /etc/hosts
+  has_metadata_entry=$(egrep '^169\.254\.169\.254' /etc/hosts)
+  if [ -z "$has_metadata_entry" ]; then
+      echo "169.254.169.254 metadata.google.internal  # Added by Google" >> /etc/hosts
+  fi
 fi
 
 # /sbin/dhclient-scripts in both ubuntu and centos have some problems for us:


### PR DESCRIPTION
In cases where the metadata server /etc/hosts entry was not added by the guest environment scripts there will be no "# Added by Google" marker. As such the script will add a second reference to the metadata if it already exists. We should only have 1 entry. Respect the already existing entry and do not add a second entry.