### PR TITLE
Revert "Include systemd-networkd hook in Ubuntu packaging (#77)"

### DIFF
--- a/packaging/ubuntu/install
+++ b/packaging/ubuntu/install
@@ -5,7 +5,6 @@ src/etc/rsyslog.d/* etc/rsyslog.d
 src/etc/sysctl.d/* etc/sysctl.d
 src/lib/udev/* lib/udev
 src/usr/bin/* usr/bin
-src/usr/lib/networkd-dispatcher/* usr/lib/networkd-dispatcher
 src/etc/systemd/resolved.conf.d/* etc/systemd/resolved.conf.d
 
 # Ubuntu-specific configuration


### PR DESCRIPTION
This reverts commit 50c546896f5643ad35c0c49453ecb9ea4c99b585.

This change introduced a regression with hostname setup where it conflicts with cloud-init use cases supported by Ubuntu.