### PR TITLE
Disable DNSSEC in systemd-resolved.

### DIFF
--- a/src/etc/systemd/resolved.conf.d/gce-resolved.conf
+++ b/src/etc/systemd/resolved.conf.d/gce-resolved.conf
@@ -20,4 +20,6 @@ MulticastDNS=false
 # Systemd-resolved will still pick the right server from DHCP, but if we don't
 # explicilty configure it here we can't use it for .local domains.
 DNS=169.254.169.254
-
+# Disable DNSSEC which, if enabled, will fail to resolve DNS on gvnic machine
+# types on any distribution.
+DNSSEC=no


### PR DESCRIPTION
If systemd-resolved is set to use DNSSEC on any gvnic enabled VM, DNS resolution will fail. This can be reproduced on any Linux distribution using systemd-resolved. Most distributions disable DNSSEC by default already but some do not.

Note that virtio-net based VM's work fine with DNSSEC enabled.

DNSSEC validation failures look like
```
resolvectl query nvd.nist.gov
nvd.nist.gov: resolve call failed: DNSSEC validation failed: failed-auxiliary
```

On Debian 12, you can reproduce this by enabling DNSSEC (as root) on an N4 or C3 machine type
```
echo "DNSSEC=yes" >> /etc/systemd/resolved.conf.d/gce-resolved.conf
systemctl restart systemd-resolved
resolvectl query nvd.nist.gov   # or any DNS lookup
nvd.nist.gov: resolve call failed: DNSSEC validation failed: failed-auxiliary
```